### PR TITLE
docs: updated skill icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <div align="center">
 <h1> Hi there 👋, I'm Alberto </h1>
 
-[![My Skills](https://skillicons.dev/icons?i=php,java,py,rust,c,js,ts,html,css,bootstrap,jquery,jest,twitter,wordpress,nodejs,express,vue,react,laravel,tauri,github,gitlab,idea,vscode,latex,mongodb,postgres,mysql,ai,ps)](https://skillicons.dev)
+[![My Skills](https://skillicons.dev/icons?i=php,js,ts,html,css,bootstrap,jest,wordpress,postman,aws,azure,flutter,nodejs,vue,react,terraform,graphql,github,gitlab,idea,vscode,latex,java,kotlin,py,rust,c,postgres,mysql,dynamodb,pr,ai,ps&perline=11)](https://skillicons.dev)
 
 ![Most Used Languages](https://github-readme-stats-albertobaroso.vercel.app/api/top-langs/?username=albertobaroso&layout=compact&theme=dark&exclude_repo=computer-architectures-pong)
 </div>


### PR DESCRIPTION
Updated skill icons:
- Removed: jquery, twitter, express, mongodb, laravel, tauri
- Added: kotlin, terraform, aws, azure, postman, premiere pro

Refactor: 
- Grouped icons by functionality, e.g. DBMSs, Cloud providers, Web development, ...